### PR TITLE
feat: add hot pink button variant for New Design button

### DIFF
--- a/src/components/HeaderActions.tsx
+++ b/src/components/HeaderActions.tsx
@@ -155,7 +155,7 @@ export function HeaderActions({ user, projectId }: HeaderActionsProps) {
         </Popover>
       )}
 
-      <Button variant="green" className="flex items-center gap-2 h-8" onClick={handleNewDesign}>
+      <Button variant="hotpink" className="flex items-center gap-2 h-8" onClick={handleNewDesign}>
         <Plus className="h-4 w-4" />
         New Design
       </Button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -22,6 +22,8 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
         green:
           "bg-green-600 text-white shadow-xs hover:bg-green-700 focus-visible:ring-green-600/20 dark:focus-visible:ring-green-600/40",
+        hotpink:
+          "bg-pink-500 text-white shadow-xs hover:bg-pink-600 focus-visible:ring-pink-500/20 dark:focus-visible:ring-pink-500/40",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",


### PR DESCRIPTION
This PR changes the "New Design" button color to hot pink as requested in issue #3.

## Changes
- Added hotpink variant to button component with bg-pink-500 and hover:bg-pink-600 styles
- Updated HeaderActions component to use hotpink variant for New Design button

Fixes #3

Generated with [Claude Code](https://claude.ai/code)